### PR TITLE
R2 NFDB, Realforce RT1 numpad, and the Norbauer Datapad

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,6 @@ Tested a sample cable using manufactured PH crimped wires in an EH cable housing
 ![CableEHToPH](https://i.imgur.com/tfvrSqY.png)
 </details>
 
-# Special thanks 
-* Nekotato: for requesting, testing & driving this project
-* Techbeezin: for test fitting the vast collection of Norbaforces 
-* Cipulot: Answering various questions regarding Realforce and general electrical questions/advice
-
 # Notes
 <details>
   <summary>R2 NFDB and the Realforce RT1 (2024 release)</summary>
@@ -94,3 +89,8 @@ Norbaforce MKII (slight internal filing was needed)
 Norbauer Data Pad
 ![DataPad](https://i.imgur.com/ypJBltZ.jpg)
 </details>
+
+# Special thanks 
+* Nekotato: for requesting, testing & driving this project
+* Techbeezin: for test fitting the vast collection of Norbaforces 
+* Cipulot: Answering various questions regarding Realforce and general electrical questions/advice

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _(Note there is one PCB that can have a connector for Realforce 1 OR Realforce 2
 * **Cable:** PH to PH (2.0mm pitch), 5 pin, REVERSED Direction, Length 11cm
 
 ![RF2Pinnout](https://i.imgur.com/rXatLpw.png)
-<br><br><br>
+<br><br>
 
 # Manufacturing
 <details>

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Tested a sample cable using manufactured PH crimped wires in an EH cable housing
 * Techbeezin: for test fitting the vast collection of Norbaforces 
 * Cipulot: Answering various questions regarding Realforce and general electrical questions/advice
 
+# Notes
+<details>
+  <summary>R2 NFDB and the Realforce RT1 (2024 release)</summary>
+The R2 NFDB may be compatible with the Topre Realforce RT1 numpad (released in 2024), which shares similar footprint to the predecessor Realforce 23u.
+[photo tbd]
+</details>  
 <details>
   <summary>Photos</summary>
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Tested a sample cable using manufactured PH crimped wires in an EH cable housing
 # Notes
 <details>
   <summary>R2 NFDB and the Realforce RT1 (Topre numpad)</summary>
-The R2 NFDB may be compatible with the Topre Realforce RT1 numpad (released in 2024), which shares a similar footprint to the predecessor Realforce 23u.
+The R2 NFDB is compatible with the Topre Realforce RT1 numpad (released in 2024), which shares a similar footprint to the predecessor Realforce 23u.
 
 photo tbd
 </details>  
@@ -87,9 +87,10 @@ Norbaforce MKII RF2
 ![NFMKiib](https://i.imgur.com/0RaRg6e.png)
 Norbaforce MKII (slight internal filing was needed)
 ![NFMKIIInside](https://i.imgur.com/2XnP7rR.jpg)
-Norbauer Data Pad
+Norbauer Data Pad and the R1 NFDB
 ![DataPad](https://i.imgur.com/ypJBltZ.jpg)
-Norbauer Data Pad with RT1 pcb and stock controller
+Norbauer Data Pad with RT1 pcb - use R2 NFDB
+![RT1](https://i.imgur.com/QSRFrbK.jpeg)
 </details>
 
 # Special thanks 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ Tested a sample cable using manufactured PH crimped wires in an EH cable housing
 
 # Notes
 <details>
-  <summary>R2 NFDB and the Realforce RT1 (2024 release)</summary>
-The R2 NFDB may be compatible with the Topre Realforce RT1 numpad (released in 2024), which shares similar footprint to the predecessor Realforce 23u.
-[photo tbd]
+  <summary>R2 NFDB and the Realforce RT1 (Topre numpad)</summary>
+
+The R2 NFDB may be compatible with the Topre Realforce RT1 numpad (released in 2024), which shares a similar footprint to the predecessor Realforce 23u.
+
+photo tbd
 </details>  
 <details>
   <summary>Photos</summary>
@@ -88,6 +90,7 @@ Norbaforce MKII (slight internal filing was needed)
 ![NFMKIIInside](https://i.imgur.com/2XnP7rR.jpg)
 Norbauer Data Pad
 ![DataPad](https://i.imgur.com/ypJBltZ.jpg)
+Norbauer Data Pad with RT1 pcb and stock controller
 </details>
 
 # Special thanks 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Tested a sample cable using manufactured PH crimped wires in an EH cable housing
 # Notes
 <details>
   <summary>R2 NFDB and the Realforce RT1 (Topre numpad)</summary>
-
 The R2 NFDB may be compatible with the Topre Realforce RT1 numpad (released in 2024), which shares a similar footprint to the predecessor Realforce 23u.
 
 photo tbd

--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ Norbaforce MKII (slight internal filing was needed)
 Norbauer Data Pad and the R1 NFDB
 ![DataPad](https://i.imgur.com/ypJBltZ.jpg)
 Norbauer Data Pad with RT1 pcb - use R2 NFDB
-![RT1](https://i.imgur.com/QSRFrbK.jpeg)
+![RT1](https://i.imgur.com/QSRFrbK.jpeg)![RT12](https://i.imgur.com/HHpbOw6.jpeg)
 </details>
 
 # Special thanks 
 * Nekotato: for requesting, testing & driving this project
 * Techbeezin: for test fitting the vast collection of Norbaforces 
-* Cipulot: Answering various questions regarding Realforce and general electrical questions/advice
+* Cipulot: answering various questions regarding Realforce and general electrical questions/advice
+* d0nk: for pre-testing the R2 OEM cabling/pinout on RT1

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Norbaforce MKI (cutout is USB shape no issues with fit)
 Norbaforce MKIII (unfinished no fit issues)
 ![NFMKII](https://i.imgur.com/ojrkUOl.jpg)
 Norbaforce MKII RF2
-![NFMKiib](https://i.imgur.com/0RaRg6e.png)
+![NFMKiib](https://i.imgur.com/GUCTGYN.jpeg)
 Norbaforce MKII (slight internal filing was needed)
 ![NFMKIIInside](https://i.imgur.com/2XnP7rR.jpg)
 Norbauer Data Pad and the R1 NFDB

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _(Note there is one PCB that can have a connector for Realforce 1 OR Realforce 2
 
 # Version Realforce R2 
   ![RenderRF2](https://i.imgur.com/hHAMaGG.jpg)
-* **Models:** R2 TKL, R2 RGB TKL
+* **Models:** R2 TKL, R2 RGB TKL, RT1 (numpad)
 * **PCB Connector:** LCSC: C69152
 * **Cable:** PH to PH (2.0mm pitch), 5 pin, REVERSED Direction, Length 11cm
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ Tested a sample cable using manufactured PH crimped wires in an EH cable housing
 # Notes
 <details>
   <summary>R2 NFDB and the Realforce RT1 (Topre numpad)</summary>
-The R2 NFDB is compatible with the Topre Realforce RT1 numpad (released in 2024), which shares a similar footprint to the predecessor Realforce 23u.
 
-photo tbd
+The R2 NFDB is compatible with the Topre Realforce RT1 numpad (released in 2024), which shares a similar footprint to the predecessor Realforce 23u.  
+![RT12](https://i.imgur.com/HHpbOw6.jpeg)
+
 </details>  
 <details>
   <summary>Photos</summary>
@@ -90,7 +91,7 @@ Norbaforce MKII (slight internal filing was needed)
 Norbauer Data Pad and the R1 NFDB
 ![DataPad](https://i.imgur.com/ypJBltZ.jpg)
 Norbauer Data Pad with RT1 pcb - use R2 NFDB
-![RT1](https://i.imgur.com/QSRFrbK.jpeg)![RT12](https://i.imgur.com/HHpbOw6.jpeg)
+![RT1](https://i.imgur.com/QSRFrbK.jpeg)
 </details>
 
 # Special thanks 


### PR DESCRIPTION
Hi Dave, 

Please see 2025 update - Realforce released a reboot of their 23u. d0nk on Discord was one of the first to get a unit and was gracious enough to tear down and explore the new pcb and internals. He did preliminary testing with an OEM R2 stock 5-pin PH cable and confirmed that it powered the stock numpad internals, so I went ahead and bought an RT1 and tested it with the NFDB R2. It works! And so does Norbauer's R2 with mini-usb. I also tidied up some formatting and refreshed some photos, etc. 

It is also possible that the R3S will work with the R2 NFDB albeit I've not had a chance to test one myself (same pcb/construct as the R2 TKLs basically.) But until then, this is all I got.

Hope all is well and talk soon.

Neko